### PR TITLE
Add Models for data objects and empty Migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/vendor/composer/autoload_classmap.php

--- a/partEZ/.gitignore
+++ b/partEZ/.gitignore
@@ -4,3 +4,4 @@ Homestead.yaml
 Homestead.json
 /.idea/*
 .env
+/vendor/composer/autoload_classmap.php

--- a/partEZ/app/Event.php
+++ b/partEZ/app/Event.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Event extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'Events';
+
+    protected $primaryKey = 'eid';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'name', 'date', 'stime', 'etime', 'location', 'description',
+    ];
+
+    /**
+     * The attributes excluded from the model's JSON form.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'uid',
+    ];
+}

--- a/partEZ/app/Invite.php
+++ b/partEZ/app/Invite.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Invite extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'Invites';
+
+    protected $primaryKey = 'eid';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'response',
+    ];
+
+    /**
+     * The attributes excluded from the model's JSON form.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'eid', 'uid',
+    ];
+}

--- a/partEZ/app/Poll.php
+++ b/partEZ/app/Poll.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Poll extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'Polls';
+
+    protected $primaryKey = 'pid';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'polltype',
+    ];
+
+    /**
+     * The attributes excluded from the model's JSON form.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'pid', 'eid',
+    ];
+}

--- a/partEZ/app/PollOption.php
+++ b/partEZ/app/PollOption.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PollOptions extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'Poll_Options';
+
+    protected $primaryKey = 'pid';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array
+     */
+    protected $fillable = [
+        'date', 'stime', 'etime', 'location', 'custom',
+    ];
+
+    /**
+     * The attributes excluded from the model's JSON form.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'oid',
+    ];
+}

--- a/partEZ/app/PollResponse.php
+++ b/partEZ/app/PollResponse.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PollResponse extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'Poll_Responses';
+
+    /**
+     * The attributes excluded from the model's JSON form.
+     *
+     * @var array
+     */
+    protected $guarded = [
+        'uid', 'oid', 'pid',
+    ];
+}

--- a/partEZ/database/migrations/2016_01_27_004532_create_events_table.php
+++ b/partEZ/database/migrations/2016_01_27_004532_create_events_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateEventsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/partEZ/database/migrations/2016_01_27_004619_create_invites_table.php
+++ b/partEZ/database/migrations/2016_01_27_004619_create_invites_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateInvitesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/partEZ/database/migrations/2016_01_27_004641_create_polls_table.php
+++ b/partEZ/database/migrations/2016_01_27_004641_create_polls_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePollsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/partEZ/database/migrations/2016_01_27_004712_create_poll_options_table.php
+++ b/partEZ/database/migrations/2016_01_27_004712_create_poll_options_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePolloptionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/partEZ/database/migrations/2016_01_27_004742_create_poll_responses_table.php
+++ b/partEZ/database/migrations/2016_01_27_004742_create_poll_responses_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePollresponsesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        //
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/partEZ/vendor/composer/autoload_classmap.php
+++ b/partEZ/vendor/composer/autoload_classmap.php
@@ -6,7 +6,12 @@ $vendorDir = dirname(dirname(__FILE__));
 $baseDir = dirname($vendorDir);
 
 return array(
+    'CreateEventsTable' => $baseDir . '/database/migrations/2016_01_27_004532_create_events_table.php',
+    'CreateInvitesTable' => $baseDir . '/database/migrations/2016_01_27_004619_create_invites_table.php',
     'CreatePasswordResetsTable' => $baseDir . '/database/migrations/2014_10_12_100000_create_password_resets_table.php',
+    'CreatePolloptionsTable' => $baseDir . '/database/migrations/2016_01_27_004712_create_poll_options_table.php',
+    'CreatePollresponsesTable' => $baseDir . '/database/migrations/2016_01_27_004742_create_poll_responses_table.php',
+    'CreatePollsTable' => $baseDir . '/database/migrations/2016_01_27_004641_create_polls_table.php',
     'CreateUsersTable' => $baseDir . '/database/migrations/2014_10_12_000000_create_users_table.php',
     'DatabaseSeeder' => $baseDir . '/database/seeds/DatabaseSeeder.php',
     'File_Iterator' => $vendorDir . '/phpunit/php-file-iterator/src/Iterator.php',


### PR DESCRIPTION
Add models and migrations for Events, Invites, Polls, PollOptions, and PollResponses.

@delroyhiebert, related to our discussion about composite keys in Eloquent, there shouldn't be a problem. The only thing to note is that the models only specify one primary key for the tables Poll_Options and Poll_Responses, but the database tables themselves should be able to have composite keys. It's just how we search for stuff that changes.

see below for details: 

http://stackoverflow.com/questions/28904194/laravel-eloquent-find-for-composite-key

ps. The link also explains why an array as a models primary key won't work. 

@JenCabral @GregJoubert @maxewaschuk 
